### PR TITLE
Added Missing Company Attribute

### DIFF
--- a/sharedresources/src/main/resources/org/eurekastreams/server/conf/applicationContext-framework-ldap.xml
+++ b/sharedresources/src/main/resources/org/eurekastreams/server/conf/applicationContext-framework-ldap.xml
@@ -44,6 +44,7 @@
         <property name="orgAttrib" value="none" />
         <property name="titleAttrib" value="none" />
         <property name="fullNameAttrib" value="none" />
+        <property name="companyAttrib" value="none" />
         <property name="emailAttrib" value="none" />
         <property name="supportEmail" value="${eureka.mail.support.emailaddress}" />
     </bean>


### PR DESCRIPTION
The companyAttrib was left out of the ldap config file after changes were made to the LdapToPersonMapper.  Wtihout this attribute present, Eureka cannot create Person objects and the end result is everyone being locked out of the application.
