### PR TITLE
Allow setting a proxy for shindig during compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,7 @@
         <build.system.proxyport>8080</build.system.proxyport>
         <build.system.proxyset>false</build.system.proxyset>
         <build.system.nonproxyhosts>*.example.com</build.system.nonproxyhosts>
+        <build.shindig.proxy></build.shindig.proxy> <!-- e.g. proxy.example.com:8080 - leave blank for no proxy -->
         <build.db.dbname>eurekastreams</build.db.dbname>
         <build.db.dbuser>eurekastreams</build.db.dbuser>
         <build.db.dbpassword></build.db.dbpassword>

--- a/web/src/main/resources/conf/eurekastreams.properties
+++ b/web/src/main/resources/conf/eurekastreams.properties
@@ -117,7 +117,7 @@ shindig.uri.concat.use-strict-parsing=false
 
 # Host:port of the proxy to use while fetching urls. Leave blank if proxy is
 # not to be used.
-org.apache.shindig.gadgets.http.basicHttpFetcherProxy=
+org.apache.shindig.gadgets.http.basicHttpFetcherProxy=${build.shindig.proxy}
 
 org.apache.shindig.serviceExpirationDurationMinutes=60
 


### PR DESCRIPTION
Currently, it is not possible to specify a proxy to be used by shindig while accessing external resources from a gadget like a RSS feed.

Please merge this small change into your master branch.
