### PR TITLE
Downgrade slf4j library to fix execution on jetty

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.1</version>
+            <version>1.5.6</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
Currently, it is impossible to run ES on jetty, because a version conflict exists for the slf4j library. Please merge this change into your master branch.
