### PR TITLE
Removed hardcoded EntityType.GROUP from BaseActivitySubscriptionModel

### DIFF
--- a/web/src/main/java/org/eurekastreams/web/client/model/BaseActivitySubscriptionModel.java
+++ b/web/src/main/java/org/eurekastreams/web/client/model/BaseActivitySubscriptionModel.java
@@ -73,7 +73,7 @@ public class BaseActivitySubscriptionModel extends BaseModel implements Fetchabl
                 Session.getInstance()
                         .getEventBus()
                         .notifyObservers(
-new GotStreamActivitySubscriptionResponseEvent(EntityType.GROUP, uniqueId, // \n
+new GotStreamActivitySubscriptionResponseEvent(entityType, uniqueId, // \n
                                 isSubscribed));
             }
         }, useClientCacheIfAvailable);


### PR DESCRIPTION
This pull request removes hardcoded EntityType.GROUP from BaseActivitySubscriptionModel. This class works not only with groups but with persons also. So, it's necessary to pass correct entity type in each situation.
