### PR TITLE
A little 404 cleanup.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,9 +2,6 @@ Eureka Streams: A new communications experience for the enterprise
 
 Please visit <http://eurekastreams.org> for more information.
 
-For information on getting started with the code take a look at the Build And Run guide: <http://www.eurekastreams.org/build-and-run>.
+For information on getting started with the code take a look at the Installation Guide: <http://eurekastreams.org/installation-guide.html>.
 
 For developer conversation look to Eureka Streams Development in Google Groups <http://groups.google.com/group/eureka-streams-dev>.
-
-For the JavaDoc, visit this site: <http://dev.eurekastreams.org/javadoc>.
-


### PR DESCRIPTION
"Build and Run Guide" was 404, link Installation Guide instead.
Javadocs/"dev.eurekastreams.org also 404's - removed.
