### PR TITLE
TFS-26337: Wording Change on the Configure Profile page

### DIFF
--- a/server/src/main/java/org/eurekastreams/server/domain/DomainGroup.java
+++ b/server/src/main/java/org/eurekastreams/server/domain/DomainGroup.java
@@ -130,7 +130,7 @@ public class DomainGroup extends DomainEntity implements AvatarEntity, Followabl
 
     /** Used for validation. */
     @Transient
-    public static final String SHORT_NAME_CHARACTERS = "A short name can only contain "
+    public static final String SHORT_NAME_CHARACTERS = "A Group Web Address can only contain "
             + "alphanumeric characters and no spaces.";
 
     /** Pattern for validating legal group names. */

--- a/web/src/main/resources/public/scripts/eureka-apps.js
+++ b/web/src/main/resources/public/scripts/eureka-apps.js
@@ -984,6 +984,7 @@ Eureka.PostBox = function(text, postcb, maxlength, contentWarning)
             if (!post.hasClass('post-button-disabled'))
             {
 			    var comment = commentInput.val();
+			    comment = comment.replace(/\\/g, "");
     			postcb(comment);
 	    		commentInput.val("");
 		    	postComment.hide();


### PR DESCRIPTION
The validation message for the Group web address field was reading A
short name can only contain alphanumeric characters and no spaces.

The text was updated to say Group Web Address rather than short name.
